### PR TITLE
Updated version that works with browserify, and fixes unnecessary purging 

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -131,16 +131,9 @@ Cache.prototype.setItem = function(key, value, options) {
   if (this.storage_.get(key) != null) {
     this.removeItem(key);
   }
-  this.addItem_(new Cache._CacheItem(key, value, options));
   this.log_("Setting key " + key);
-
-  // if the cache is full, purge it
-  if ((this.maxSize_ > 0) && (this.size() > this.maxSize_)) {
-    var that = this;
-    setTimeout(function() {
-      that.purge_.call(that);
-    }, 0);
-  }
+  this.addItem_(new Cache._CacheItem(key, value, options));
+  this.checkMaxSize_();
 };
 
 
@@ -187,16 +180,23 @@ Cache.prototype.toHtmlString = function() {
  */
 Cache.prototype.resize = function(newMaxSize) {
   this.log_('Resizing Cache from ' + this.maxSize_ + ' to ' + newMaxSize);
-  // Set new size before purging so we know how many items to purge
   this.maxSize_ = newMaxSize;
+  this.checkMaxSize_();
+}
 
+/**
+ * if the cache is full, purge it
+ * @private
+ */
+Cache.prototype.checkMaxSize_ = function() {
   if ((this.maxSize_ > 0) && (this.size() > this.maxSize_)) {
     // Cache needs to be purged as it does contain too much entries for the new size
-    this.purge_();
+    var that = this;
+    setTimeout(function() {
+      that.purge_.call(that);
+    }, 0);
   }
-  // else if newMaxSize >= maxSize nothing to do
-  this.log_('Resizing done');
-}
+};
 
 /**
  * Removes expired items from the cache.

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -195,10 +195,10 @@ Cache.prototype.checkMaxSize_ = function() {
 
   if ((this.maxSize_ > 0) && (this.size() > this.maxSize_)) {
     // Cache needs to be purged as it does contain too much entries for the new size
-    var that = this;
+    var self = this;
     this.pendingPurge_ = true;
     setTimeout(function() {
-      that.purge_.call(that);
+      self.purge_();
     }, 0);
   }
 };

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -33,14 +33,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 function Cache(maxSize, debug, storage) {
     this.maxSize_ = maxSize || -1;
     this.debug_ = debug || false;
-    this.storage_ = storage || 'basic';
-    if (typeof this.storage_ == 'string') {
-        try {
-            this.storage_ = new (require('./stores/'+this.storage_.toLowerCase().trim()));
-        } catch(e) {
-            throw new Error('There is no bundled caching store named "'+this.storage_+'"');
-        }
-    }
+    this.storage_ = storage || new (require('./stores/basic'))();
     this.fillFactor_ = .75;
 
     this.stats_ = {};

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -188,14 +188,11 @@ Cache.prototype.toHtmlString = function() {
 Cache.prototype.resize = function(newMaxSize) {
   this.log_('Resizing Cache from ' + this.maxSize_ + ' to ' + newMaxSize);
   // Set new size before purging so we know how many items to purge
-  var oldMaxSize = this.maxSize_
   this.maxSize_ = newMaxSize;
 
-  if (newMaxSize > 0 && (oldMaxSize < 0 || newMaxSize < oldMaxSize)) {
-    if (this.size() > newMaxSize) {
-      // Cache needs to be purged as it does contain too much entries for the new size
-      this.purge_();
-    } // else if cache isn't filled up to the new limit nothing is to do
+  if ((this.maxSize_ > 0) && (this.size() > this.maxSize_)) {
+    // Cache needs to be purged as it does contain too much entries for the new size
+    this.purge_();
   }
   // else if newMaxSize >= maxSize nothing to do
   this.log_('Resizing done');

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -35,6 +35,7 @@ function Cache(maxSize, debug, storage) {
     this.debug_ = debug || false;
     this.storage_ = storage || new (require('./stores/basic'))();
     this.fillFactor_ = .75;
+    this.pendingPurge_ = false;
 
     this.stats_ = {};
     this.stats_['hits'] = 0;
@@ -189,9 +190,13 @@ Cache.prototype.resize = function(newMaxSize) {
  * @private
  */
 Cache.prototype.checkMaxSize_ = function() {
+  if (this.pendingPurge_)
+    return;
+
   if ((this.maxSize_ > 0) && (this.size() > this.maxSize_)) {
     // Cache needs to be purged as it does contain too much entries for the new size
     var that = this;
+    this.pendingPurge_ = true;
     setTimeout(function() {
       that.purge_.call(that);
     }, 0);
@@ -234,6 +239,7 @@ Cache.prototype.purge_ = function() {
       this.removeItem(ritem.key);
     }
   }
+  this.pendingPurge_ = false;
   this.log_('Purged cached');
 };
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "optionalDependencies": {},
   "scripts": {
-    "test": "mocha -R spec"
+    "test": "mocha --compilers coffee:coffee-script/register -R spec"
   }
 }

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -162,12 +162,14 @@ describe 'Cache', ->
       @clock.tick INTERVAL
       cache.setItem "foo3", "bar3"
       cache.resize 2
+      @clock.tick INTERVAL
       should.not.exist cache.getItem("foo1")
       cache.getItem("foo2").should.equal "bar2"
 
       @clock.tick INTERVAL
       cache.getItem("foo3").should.equal "bar3"
       cache.resize 1
+      @clock.tick INTERVAL
       should.not.exist cache.getItem("foo1")
       should.not.exist cache.getItem("foo2")
       cache.getItem("foo3").should.equal "bar3"

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -5,206 +5,205 @@ chai.use require 'sinon-chai'
 should = chai.should()
 
 INTERVAL = 5
-defer = (i, fn) =>
-    setTimeout fn, INTERVAL*i
+defer = (i, fn) ->
+  setTimeout fn, INTERVAL*i
 
 describe 'Cache', ->
 
-    before ->
-        @clock = sinon.useFakeTimers()
+  before ->
+    @clock = sinon.useFakeTimers()
 
-    after ->
-        @clock.restore()
+  after ->
+    @clock.restore()
 
-    describe 'basics', ->
+  describe 'basics', ->
 
-        beforeEach ->
-            @cache = new Cache
+    beforeEach ->
+      @cache = new Cache
 
-        it 'should set and get item', ->
-            @cache.setItem "foo", "bar"
-            @cache.getItem("foo").should.equal "bar"
+    it 'should set and get item', ->
+      @cache.setItem "foo", "bar"
+      @cache.getItem("foo").should.equal "bar"
 
-        it 'should remove item', ->
-            should.not.exist @cache.getItem("foo")
-            @cache.setItem "foo", "bar"
-            should.exist @cache.getItem("foo")
-            should.exist @cache.removeItem("foo")
-            should.not.exist @cache.getItem("foo")
+    it 'should remove item', ->
+      should.not.exist @cache.getItem("foo")
+      @cache.setItem "foo", "bar"
+      should.exist @cache.getItem("foo")
+      should.exist @cache.removeItem("foo")
+      should.not.exist @cache.getItem("foo")
 
-        it 'should not get missing item', ->
-            should.not.exist @cache.getItem("missing")
+    it 'should not get missing item', ->
+      should.not.exist @cache.getItem("missing")
 
-        it 'should not remove missing item', ->
-            should.not.exist @cache.removeItem("missing")
+    it 'should not remove missing item', ->
+      should.not.exist @cache.removeItem("missing")
 
-        it 'should register stats', ->
-            @cache.setItem "foo", "bar"
-            @cache.getItem("foo")
-            @cache.getItem("missing")
-            @cache.removeItem("missing")
-            stats = @cache.getStats()
-            stats.hits.should.equal 1
-            stats.misses.should.equal 1
+    it 'should register stats', ->
+      @cache.setItem "foo", "bar"
+      @cache.getItem("foo")
+      @cache.getItem("missing")
+      @cache.removeItem("missing")
+      stats = @cache.getStats()
+      stats.hits.should.equal 1
+      stats.misses.should.equal 1
 
-        it 'should generate an HTML report', ->
-            @cache.setItem "foo", "bar"
-            @cache.toHtmlString().should.equal "1 item(s) in cache<br /><ul><li>foo = bar</li></ul>"
+    it 'should generate an HTML report', ->
+      @cache.setItem "foo", "bar"
+      @cache.toHtmlString().should
+        .equal "1 item(s) in cache<br /><ul><li>foo = bar</li></ul>"
 
-        it 'should register cache size', ->
-            @cache.setItem "foo", "bar"
-            @cache.size().should.equal 1
+    it 'should register cache size', ->
+      @cache.setItem "foo", "bar"
+      @cache.size().should.equal 1
 
-            @cache.setItem "foo2", "bar2"
-            @cache.size().should.equal 2
-            @cache.removeItem("foo")
-            @cache.size().should.equal 1
-            @cache.clear()
-            should.not.exist @cache.getItem("foo")
-            should.not.exist @cache.getItem("foo2")
-            @cache.size().should.equal 0
+      @cache.setItem "foo2", "bar2"
+      @cache.size().should.equal 2
+      @cache.removeItem("foo")
+      @cache.size().should.equal 1
+      @cache.clear()
+      should.not.exist @cache.getItem("foo")
+      should.not.exist @cache.getItem("foo2")
+      @cache.size().should.equal 0
 
-    describe 'absolute expiration', ->
+  describe 'absolute expiration', ->
 
-        beforeEach ->
-            @cache = new Cache
+    beforeEach ->
+      @cache = new Cache
 
-            @cache.setItem "foo", "bar",
-                expirationAbsolute: new Date(new Date().getTime() + INTERVAL*2)
+      @cache.setItem "foo", "bar",
+          expirationAbsolute: new Date(new Date().getTime() + INTERVAL*2)
 
-            @cache.getItem("foo").should.equal "bar"
+      @cache.getItem("foo").should.equal "bar"
 
-        it 'should expire', (done) ->
+    it 'should expire', (done) ->
+      defer 3, =>
+        should.not.exist @cache.getItem("foo")
+        done()
 
-            defer 3, =>
-                should.not.exist @cache.getItem("foo")
-                done()
+      @clock.tick INTERVAL*3
 
-            @clock.tick INTERVAL*3
+    it 'should not expire', ->
+      defer 1, =>
+        @cache.getItem("foo").should.equal "bar"
 
-        it 'should not expire', ->
+      @clock.tick INTERVAL*3
 
-            defer 1, =>
-                @cache.getItem("foo").should.equal "bar"
+  describe 'sliding expiration', ->
 
-            @clock.tick INTERVAL*3
+    it 'should expire', (done) ->
+      cache = new Cache
 
-    describe 'sliding expiration', ->
+      cache.setItem "foo", "bar",
+          expirationSliding: INTERVAL * 2 / 1000
 
-        it 'should expire', (done) ->
-            cache = new Cache
+      cache.getItem("foo").should.equal "bar"
 
-            cache.setItem "foo", "bar",
-                expirationSliding: INTERVAL * 2 / 1000
-
+      defer 1, ->
+        cache.getItem("foo").should.equal "bar"
+        defer 1, ->
+          cache.getItem("foo").should.equal "bar"
+          defer 1, ->
             cache.getItem("foo").should.equal "bar"
+            defer 3, ->
+              should.not.exist cache.getItem("foo")
+              done()
 
-            defer 1, ->
-                cache.getItem("foo").should.equal "bar"
-                defer 1, ->
-                    cache.getItem("foo").should.equal "bar"
-                    defer 1, ->
-                        cache.getItem("foo").should.equal "bar"
-                        defer 3, ->
-                            should.not.exist cache.getItem("foo")
-                            done()
+      @clock.tick INTERVAL*6
 
-            @clock.tick INTERVAL*6
+  describe 'LRU expiration', ->
 
-    describe 'LRU expiration', ->
+    it 'should expire', (done) ->
+      cache = new Cache 2
+      cache.setItem "foo1", "bar1"
+      cache.setItem "foo2", "bar2"
+      defer 1, ->
+        # Access an item so foo1 will be the LRU
+        cache.getItem("foo2").should.equal "bar2"
 
-        it 'should expire', (done) ->
-            cache = new Cache 2
-            cache.setItem "foo1", "bar1"
-            cache.setItem "foo2", "bar2"
-            defer 1, ->
-                # Access an item so foo1 will be the LRU
-                cache.getItem("foo2").should.equal "bar2"
+        cache.setItem "foo3", "bar3"
+        cache.size().should.equal 3
 
-                cache.setItem "foo3", "bar3"
-                cache.size().should.equal 3
+        # Allow time for cache to be purged
+        defer 1, ->
+          should.not.exist cache.getItem("foo1")
+          cache.getItem("foo2").should.equal "bar2"
+          cache.getItem("foo3").should.equal "bar3"
+          cache.size().should.equal 2
+          done()
 
-                # Allow time for cache to be purged
-                defer 1, ->
-                    should.not.exist cache.getItem("foo1")
-                    cache.getItem("foo2").should.equal "bar2"
-                    cache.getItem("foo3").should.equal "bar3"
-                    cache.size().should.equal 2
-                    done()
+      @clock.tick INTERVAL*2
 
-            @clock.tick INTERVAL*2
+  describe 'priority expiration', ->
 
-    describe 'priority expiration', ->
+    it 'should expire', (done) ->
+      cache = new Cache 2
+      cache.setItem "foo1", "bar1",
+          priority: Cache.Priority.HIGH
 
-        it 'should expire', (done) ->
-            cache = new Cache 2
-            cache.setItem "foo1", "bar1",
-                priority: Cache.Priority.HIGH
+      cache.setItem "foo2", "bar2"
+      defer 1, ->
+        # Access an item so foo1 will be the LRU
+        cache.getItem("foo2").should.equal "bar2"
 
-            cache.setItem "foo2", "bar2"
-            defer 1, ->
-                # Access an item so foo1 will be the LRU
-                cache.getItem("foo2").should.equal "bar2"
+        defer 1, ->
+          cache.setItem "foo3", "bar3"
+          cache.size().should.equal 3
 
-                defer 1, ->
-                    cache.setItem "foo3", "bar3"
-                    cache.size().should.equal 3
+          # Allow time for cache to be purged
+          defer 1, ->
+            cache.getItem("foo1").should.equal "bar1"
+            should.not.exist cache.getItem("foo2")
+            cache.getItem("foo3").should.equal "bar3"
+            cache.size().should.equal 2
+            done()
 
-                    # Allow time for cache to be purged
-                    defer 1, ->
-                        cache.getItem("foo1").should.equal "bar1"
-                        should.not.exist cache.getItem("foo2")
-                        cache.getItem("foo3").should.equal "bar3"
-                        cache.size().should.equal 2
-                        done()
+      @clock.tick INTERVAL*3
 
-            @clock.tick INTERVAL*3
+  describe 'sizing', ->
 
-    describe 'sizing', ->
+    it 'should resize', (done) ->
+      cache = new Cache
+      cache.setItem "foo1", "bar1"
+      defer 1, ->
+        cache.setItem "foo2", "bar2"
+        defer 1, ->
+          cache.setItem "foo3", "bar3"
+          cache.resize 2
+          should.not.exist cache.getItem("foo1")
+          cache.getItem("foo2").should.equal "bar2"
+          defer 1, ->
+            cache.getItem("foo3").should.equal "bar3"
+            cache.resize 1
+            should.not.exist cache.getItem("foo1")
+            should.not.exist cache.getItem("foo2")
+            cache.getItem("foo3").should.equal "bar3"
+            done()
 
-        it 'should resize', (done) ->
-            cache = new Cache
-            cache.setItem "foo1", "bar1"
-            defer 1, ->
-                cache.setItem "foo2", "bar2"
-                defer 1, ->
-                    cache.setItem "foo3", "bar3"
-                    cache.resize 2
-                    should.not.exist cache.getItem("foo1")
-                    cache.getItem("foo2").should.equal "bar2"
-                    defer 1, ->
-                        cache.getItem("foo3").should.equal "bar3"
-                        cache.resize 1
-                        should.not.exist cache.getItem("foo1")
-                        should.not.exist cache.getItem("foo2")
-                        cache.getItem("foo3").should.equal "bar3"
-                        done()
+      @clock.tick INTERVAL*3
 
-            @clock.tick INTERVAL*3
+    it 'should use a fill factor', (done) ->
+      cache = new Cache 100
+      counter = 0
+      cache.setItem "foo" + i, "bar" + i for i in [1..100]
 
-        it 'should use a fill factor', (done) ->
-            cache = new Cache 100
-            counter = 0
-            cache.setItem "foo" + i, "bar" + i for i in [1..100]
+      cache.size().should.equal 100
+      defer 1, ->
+        cache.size().should.equal 100
+        cache.setItem "purge", "do it"
+        defer 1, ->
+          cache.size().should.equal 75
+          done()
 
-            cache.size().should.equal 100
-            defer 1, ->
-                cache.size().should.equal 100
-                cache.setItem "purge", "do it"
-                defer 1, ->
-                    cache.size().should.equal 75
-                    done()
+      @clock.tick INTERVAL*2
 
-            @clock.tick INTERVAL*2
+  it 'should callback on purge', ->
+    cache = new Cache
+    spy = sinon.spy()
+    cache.setItem "foo", "bar",
+        onPurge: spy
+    cache.removeItem "foo"
 
-    it 'should callback on purge', ->
-        cache = new Cache
-        spy = sinon.spy()
-        cache.setItem "foo", "bar",
-            onPurge: spy
-        cache.removeItem "foo"
+    @clock.tick 1
 
-        @clock.tick 1
-
-        spy.should.have.been.calledWith "foo", "bar"
+    spy.should.have.been.calledWith "foo", "bar"
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -198,3 +198,17 @@ describe 'Cache', ->
     @clock.tick INTERVAL
 
     spy.should.have.been.calledWith "foo", "bar"
+
+  describe 'when max size is exceeded', ->
+    it 'should purge once', ->
+      cache = new Cache(10)
+      spy = sinon.spy(cache, 'purge_')
+
+      for k in [0...20]
+        cache.setItem "foo#{k}", "bar#{k}"
+
+      @clock.tick()
+
+      cache.size().should.be.lessThan 10
+      spy.should.have.been.calledOnce
+      spy.restore()

--- a/test/test_local_storage.coffee
+++ b/test/test_local_storage.coffee
@@ -1,0 +1,74 @@
+Cache = require '../'
+LocalStorageCacheStorage = require '../lib/stores/local_storage'
+sinon = require 'sinon'
+chai = require 'chai'
+chai.should()
+
+describe 'LocalStorageCacheStorage', ->
+
+  class MockLocalStorage
+    Object.defineProperty @::, 'length', get: ->
+      l = 0
+      for own k of this
+        l++
+      l
+
+    clear: ->
+      for own key of this
+        delete this[key]
+
+  global.localStorage = new MockLocalStorage()
+
+  before ->
+    @clock = sinon.useFakeTimers()
+
+  after ->
+    @clock.restore()
+
+  afterEach ->
+    localStorage.clear()
+
+  it 'stores items in localStorage', ->
+    cache = new Cache(2, false, new LocalStorageCacheStorage())
+    cache.setItem "foo1", "bar1"
+
+    @clock.tick()
+    cache.size().should.equal 1
+    localStorage.length.should.equal 1
+
+    cache.setItem "foo2", "bar2"
+    cache.setItem "foo3", "bar3"
+
+    @clock.tick()
+    cache.size().should.equal 2
+    localStorage.length.should.equal 2
+
+    cache.clear()
+    cache.size().should.equal 0
+    localStorage.length.should.equal 0
+
+  it 'shares items between caches with the same namespace', ->
+    cache1 = new Cache(-1, false, new LocalStorageCacheStorage('a'))
+    cache1.setItem "foo", "bar"
+    cache2 = new Cache(-1, false, new LocalStorageCacheStorage('a'))
+    cache1.size().should.equal 1
+    cache2.size().should.equal 1
+    localStorage.length.should.equal 1
+    cache2.removeItem "foo"
+    cache1.size().should.equal 0
+    cache2.size().should.equal 0
+    localStorage.length.should.equal 0
+
+  it 'does not share items between caches with different namespace', ->
+    cache1 = new Cache(-1, false, new LocalStorageCacheStorage('a'))
+    cache1.setItem "foo", "bar"
+    cache2 = new Cache(-1, false, new LocalStorageCacheStorage('b'))
+    cache1.size().should.equal 1
+    cache2.size().should.equal 0
+    localStorage.length.should.equal 1
+    cache2.setItem "foo", "bar"
+    localStorage.length.should.equal 2
+    cache1.removeItem "foo"
+    cache1.size().should.equal 0
+    cache2.size().should.equal 1
+    localStorage.length.should.equal 1


### PR DESCRIPTION
The purpose of this PR is to see if there is anyone paying attention to this project.

We're been using (a copy of) Monsur Hossain's jacache in our software for several years. Now we need to fix a couple of issues, and would like to use it as a proper npm package, using browserify.

I found this fork that has already done some of the work of porting it to npm. I've re-purposed this for browserify, by removing the "dynamic" require calls, and added new tests for the localStorage backend.

I've also fixed an issue with the purge function being called many times when adding many items to a full cache.

Now, I would like to start pushing this to npm, and maybe set up a travis-ci job for running the tests. The question is, would it be Ok if I just went ahead and published this as "cachai" on npm, or do you want to hold on to the maintainer status, as the one that came up with the name?
